### PR TITLE
VC mode clean

### DIFF
--- a/circuit-control.ino
+++ b/circuit-control.ino
@@ -359,7 +359,7 @@ void volumeControl(){
     }else {
       //the patient is still exhaling
       loopTimer = millis() - loopTimer; // calculate time of last loop
-      expVolume += flowOut *loopTimer; //update breath volume based on current volumetric flow rate
+      expVolume += flowOut *loopTimer; //update breath volume based on current volumetric flow rate (CHECK UNITS)
       //add O2 concentration control function here
     }
     


### PR DESCRIPTION
Here is the code for volume control. I have put it in the circuit-control.ino file under "vent Algorithms". in addition to the volumeControl function, I have added a beginBreath() and endBreath() functions that are called within the volumeControl function. These two smaller functions could be used in the PS mode as well as VC mode, I think, because the same sequence of events needs to happen to begin/end a breath in both modes. 

The VC code more or less follows the decision tree that we submitted in phase 1 of the competition. The one major difference is that the new algorithm uses PID control instead of just decision trees to manage the inspiratory flow. In that way, this new VC code is simpler and easier to read than the pseudo-code was.